### PR TITLE
Updated policy attachment resource to aws_iam_role_policy_attachment

### DIFF
--- a/sonarqube.tf
+++ b/sonarqube.tf
@@ -268,20 +268,16 @@ ROLE
 }
 
 
-resource "aws_iam_policy_attachment" "sonarqube_ecs_service" {
-
-  name       = "sonarqube-ecs-service"
-  roles      = ["${aws_iam_role.sonarqube_ecs.name}"]
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
-
+resource "aws_iam_role_policy_attachment" "sonarqube_ecs_service" {
+  name        = "sonarqube-ecs-service"
+  policy_arn  = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+  role        = "${aws_iam_role.sonarqube_ecs.name}"
 }
 
-resource "aws_iam_policy_attachment" "sonarqube_ecs_elb" {
-
-  name       = "sonarqube-ecs-elb"
-  roles      = ["${aws_iam_role.sonarqube_ecs.name}"]
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole"
-
+resource "aws_iam_role_policy_attachment" "sonarqube_ecs_elb" {
+  name        = "sonarqube-ecs-elb"
+  role        = "${aws_iam_role.sonarqube_ecs.name}"
+  policy_arn  = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole"
 }
 
 


### PR DESCRIPTION
Updated policy attachment resource to aws_iam_role_policy_attachment as aws_iam_policy_attachment may cause issues.

https://www.terraform.io/docs/providers/aws/r/iam_policy_attachment.html

In my personal experience using this code, aws_iam_policy_attachment tried to detach the policy from other IAM roles even not specified in the "roles" proprerty